### PR TITLE
feat: add support for bytes and bytearray conversions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ dependencies = []
 
 ```python
 # app/python/example.py
-def hello(name="World"):
+def hello(name):
     return f"Hello, {name}! From Python."
 ```
 
@@ -102,7 +102,7 @@ def hello(name="World"):
 class GreetingsController < ApplicationController
   def index
     example = Rubyx.import('example')
-    render json: { message: example.hello(params[:name]).to_ruby }
+    render json: { message: example.hello(params[:name] || 'World').to_ruby }
   end
 end
 ```
@@ -159,7 +159,7 @@ class TasksController < ApplicationController
     tasks = Rubyx.import('tasks')
 
     # Non-blocking — returns a Future immediately
-    future = Rubyx.async_await(tasks.delayed_greet(params[:name], seconds: 2))
+    future = Rubyx.async_await(tasks.delayed_greet(params[:name] || 'World', seconds: 2))
     do_other_work()
     render json: { message: future.await.to_ruby }
   end
@@ -331,7 +331,29 @@ Rubyx.eval("f'Hello, {name}!'", name: "World").to_ruby # => "Hello, World!"
 Rubyx.eval("max(items)", items: [3, 1, 4, 1, 5]).to_ruby # => 5
 ```
 
-Supports: Integer, Float, String, Symbol, Bool, nil, Array, Hash, and RubyxObject.
+Supports: Integer, Float, String, Symbol, Bool, nil, Array, Hash, binary String (ASCII-8BIT), and RubyxObject.
+
+## Bytes / Binary Data
+
+Python `bytes` and `bytearray` convert to Ruby `String` with `ASCII-8BIT` encoding. Ruby binary strings (`.b`) convert to Python `bytes`:
+
+```ruby
+# Python bytes → Ruby
+Rubyx.eval("b'hello'").to_ruby # => "hello" (ASCII-8BIT)
+Rubyx.eval("bytearray(b'hello')").to_ruby # => "hello" (ASCII-8BIT)
+
+# Ruby → Python
+ctx = Rubyx.context
+ctx.eval("type(data).__name__", data: "hello".b) # => "bytes"
+ctx.eval("type(data).__name__", data: "hello")   # => "str"
+
+# Roundtrip binary data
+ctx.eval("data", data: "\xff\x00\xfe".b).to_ruby # => "\xFF\x00\xFE" (ASCII-8BIT)
+
+# Works with Python stdlib
+ctx.eval("import base64")
+ctx.eval("base64.b64encode(raw)", raw: "Hello".b).to_ruby # => "SGVsbG8=" (ASCII-8BIT)
+```
 
 ## Python Objects
 
@@ -469,6 +491,37 @@ svc.Analyzer([1, 2, 3]).summary.to_ruby # => {"count" => 3, "sum" => 6}
 | `.truthy?` / `.falsy?`   | Python truthiness             |
 | `.callable?`             | Check if callable             |
 | `.py_type`               | Python type name              |
+
+## Type Conversion
+
+| Python                | Ruby                         | Notes                  |
+|-----------------------|------------------------------|------------------------|
+| `int`                 | `Integer`                    |                        |
+| `float`               | `Float`                      |                        |
+| `str`                 | `String` (UTF-8)             |                        |
+| `bytes`               | `String` (ASCII-8BIT)        | binary data            |
+| `bytearray`           | `String` (ASCII-8BIT)        | binary data            |
+| `bool`                | `true` / `false`             |                        |
+| `None`                | `nil`                        |                        |
+| `list` / `tuple`      | `Array`                      |                        |
+| `dict`                | `Hash`                       |                        |
+| `set` / `frozenset`   | `Array`                      |                        |
+| everything else       | `RubyxObject`                | proxy to Python object |
+
+**Ruby → Python** (via globals/kwargs):
+
+| Ruby                           | Python      |
+|--------------------------------|-------------|
+| `Integer`                      | `int`       |
+| `Float`                        | `float`     |
+| `String` (UTF-8)               | `str`       |
+| `String` (ASCII-8BIT / `.b`)   | `bytes`     |
+| `true` / `false`               | `bool`      |
+| `nil`                          | `None`      |
+| `Array`                        | `list`      |
+| `Hash`                         | `dict`      |
+| `Symbol`                       | `str`       |
+| `RubyxObject`                  | original    |
 
 ## Requirements
 

--- a/ext/rubyx/src/python_api.rs
+++ b/ext/rubyx/src/python_api.rs
@@ -52,6 +52,29 @@ pub struct PythonApi {
         Symbol<'static, unsafe extern "C" fn(*mut PyObject, *mut Py_ssize_t) -> *const c_char>,
     py_unicode_type: *mut PyObject,
 
+    // bytes
+    py_bytes_type: *mut PyObject,
+    py_bytes_from_string_and_size:
+        Symbol<'static, unsafe extern "C" fn(v: *const c_char, len: Py_ssize_t) -> *mut PyObject>,
+    py_bytes_as_string_and_size: Symbol<
+        'static,
+        unsafe extern "C" fn(
+            o: *mut PyObject,
+            buffer: *mut *mut c_char,
+            len: *mut Py_ssize_t,
+        ) -> c_int,
+    >,
+    py_bytes_size: Symbol<'static, unsafe extern "C" fn(o: *mut PyObject) -> Py_ssize_t>,
+
+    // bytearray
+    py_bytearray_type: *mut PyObject,
+    py_bytearray_from_object:
+        Symbol<'static, unsafe extern "C" fn(o: *mut PyObject) -> *mut PyObject>,
+    py_bytearray_from_string_and_size:
+        Symbol<'static, unsafe extern "C" fn(str: *const c_char, len: Py_ssize_t) -> *mut PyObject>,
+    py_bytearray_size: Symbol<'static, unsafe extern "C" fn(o: *mut PyObject) -> Py_ssize_t>,
+    py_bytearray_as_string: Symbol<'static, unsafe extern "C" fn(o: *mut PyObject) -> *mut c_char>,
+
     // Collection Functions
 
     // Tuple
@@ -258,6 +281,34 @@ impl PythonApi {
             unsafe extern "C" fn(*mut PyObject, *mut Py_ssize_t) -> *const c_char,
         > = lib.get(b"PyUnicode_AsUTF8AndSize")?;
         let py_unicode_type: *mut PyObject = *lib.get::<*mut PyObject>(b"PyUnicode_Type")?;
+
+        // bytes
+        let py_bytes_type = *lib.get::<*mut PyObject>(b"PyBytes_Type")?;
+        let py_bytes_from_string_and_size: Symbol<
+            unsafe extern "C" fn(*const c_char, Py_ssize_t) -> *mut PyObject,
+        > = lib.get(b"PyBytes_FromStringAndSize")?;
+        let py_bytes_as_string_and_size: Symbol<
+            unsafe extern "C" fn(
+                o: *mut PyObject,
+                buffer: *mut *mut c_char,
+                len: *mut Py_ssize_t,
+            ) -> c_int,
+        > = lib.get(b"PyBytes_AsStringAndSize")?;
+        let py_bytes_size: Symbol<unsafe extern "C" fn(*mut PyObject) -> Py_ssize_t> =
+            lib.get(b"PyBytes_Size")?;
+
+        // bytearray
+        let py_bytearray_type = *lib.get::<*mut PyObject>(b"PyByteArray_Type")?;
+        let py_bytearray_from_object: Symbol<unsafe extern "C" fn(*mut PyObject) -> *mut PyObject> =
+            lib.get(b"PyByteArray_FromObject")?;
+        let py_bytearray_from_string_and_size: Symbol<
+            unsafe extern "C" fn(*const c_char, Py_ssize_t) -> *mut PyObject,
+        > = lib.get(b"PyByteArray_FromStringAndSize")?;
+        let py_bytearray_size: Symbol<unsafe extern "C" fn(*mut PyObject) -> Py_ssize_t> =
+            lib.get(b"PyByteArray_Size")?;
+        let py_bytearray_as_string: Symbol<unsafe extern "C" fn(*mut PyObject) -> *mut c_char> =
+            lib.get(b"PyByteArray_AsString")?;
+
         // Collection Functions
         // Tuple
         let py_tuple_new: Symbol<unsafe extern "C" fn(isize) -> *mut PyObject> =
@@ -446,6 +497,22 @@ impl PythonApi {
             py_unicode_from_string_and_size: std::mem::transmute(py_unicode_from_string_and_size),
             py_unicode_as_utf8_and_size: std::mem::transmute(py_unicode_as_utf8_and_size),
             py_unicode_type,
+
+            // bytes
+            py_bytes_type,
+            py_bytes_from_string_and_size: std::mem::transmute(py_bytes_from_string_and_size),
+            py_bytes_as_string_and_size: std::mem::transmute(py_bytes_as_string_and_size),
+            py_bytes_size: std::mem::transmute(py_bytes_size),
+
+            // bytearray
+            py_bytearray_type,
+            py_bytearray_from_object: std::mem::transmute(py_bytearray_from_object),
+            py_bytearray_from_string_and_size: std::mem::transmute(
+                py_bytearray_from_string_and_size,
+            ),
+            py_bytearray_size: std::mem::transmute(py_bytearray_size),
+            py_bytearray_as_string: std::mem::transmute(py_bytearray_as_string),
+
             // Collections
             // Tuple
             py_tuple_new: std::mem::transmute(py_tuple_new),
@@ -733,6 +800,75 @@ impl PythonApi {
         } else {
             Err("expected bool".to_string())
         }
+    }
+
+    pub fn bytes_check(&self, obj: *mut PyObject) -> bool {
+        if obj.is_null() {
+            return false;
+        }
+        unsafe { (self.py_object_is_instance)(obj, self.py_bytes_type) == 1 }
+    }
+
+    pub fn bytes_from_slice(&self, data: &[u8]) -> *mut PyObject {
+        let size = data.len() as Py_ssize_t;
+        unsafe { (self.py_bytes_from_string_and_size)(data.as_ptr() as *const c_char, size) }
+    }
+
+    pub fn bytes_to_vec(&self, obj: *mut PyObject) -> Option<Vec<u8>> {
+        if !self.bytes_check(obj) {
+            return None;
+        }
+        let mut size: Py_ssize_t = 0;
+        let mut buffer: *mut c_char = std::ptr::null_mut();
+        let result = unsafe { (self.py_bytes_as_string_and_size)(obj, &mut buffer, &mut size) };
+        if result != 0 {
+            if self.has_error() {
+                self.clear_error();
+            }
+            return None;
+        }
+        if buffer.is_null() {
+            return None;
+        }
+        let slice = unsafe { std::slice::from_raw_parts(buffer as *const u8, size as usize) };
+        Some(slice.to_vec())
+    }
+
+    pub fn bytearray_check(&self, obj: *mut PyObject) -> bool {
+        if obj.is_null() {
+            return false;
+        }
+        unsafe { (self.py_object_is_instance)(obj, self.py_bytearray_type) == 1 }
+    }
+    pub fn bytearray_from_slice(&self, data: &[u8]) -> *mut PyObject {
+        let size = data.len() as Py_ssize_t;
+        unsafe { (self.py_bytearray_from_string_and_size)(data.as_ptr() as *const c_char, size) }
+    }
+
+    pub fn bytearray_to_vec(&self, obj: *mut PyObject) -> Option<Vec<u8>> {
+        if !self.bytearray_check(obj) {
+            return None;
+        }
+        let size = unsafe { (self.py_bytearray_size)(obj) };
+        if size < 0 {
+            if self.has_error() {
+                self.clear_error();
+            }
+            return None;
+        }
+        if size == 0 {
+            return Some(Vec::new());
+        }
+        let buffer = unsafe { (self.py_bytearray_as_string)(obj) };
+
+        if buffer.is_null() {
+            if self.has_error() {
+                self.clear_error();
+            }
+            return None;
+        }
+        let slice = unsafe { std::slice::from_raw_parts(buffer as *const u8, size as usize) };
+        Some(slice.to_vec())
     }
 
     pub fn tuple_new(&self, size: isize) -> *mut PyObject {
@@ -6275,6 +6411,646 @@ _loop = asyncio.new_event_loop()
         assert_eq!(size, 5);
 
         api.decref(py_set);
+        api.decref(globals);
+    }
+
+    // ========== Bytes operations ==========
+
+    #[test]
+    #[serial]
+    fn test_bytes_from_slice_creates_object() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_bytes = api.bytes_from_slice(b"hello");
+        assert!(!py_bytes.is_null(), "Should create a Python bytes object");
+        assert!(api.bytes_check(py_bytes), "Should pass bytes_check");
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_roundtrip() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        for data in [
+            b"hello" as &[u8],
+            b"world",
+            b"with spaces",
+            b"unicode: caf\xc3\xa9",
+        ] {
+            let py_bytes = api.bytes_from_slice(data);
+            assert!(!py_bytes.is_null(), "Failed to create bytes for {:?}", data);
+
+            let back = api.bytes_to_vec(py_bytes);
+            assert_eq!(
+                back.as_deref(),
+                Some(data),
+                "Roundtrip failed for {:?}",
+                data
+            );
+            api.decref(py_bytes);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_empty() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_bytes = api.bytes_from_slice(b"");
+        assert!(!py_bytes.is_null(), "Should create empty Python bytes");
+        assert!(api.bytes_check(py_bytes));
+
+        let back = api.bytes_to_vec(py_bytes);
+        assert_eq!(back, Some(Vec::new()), "Empty bytes should roundtrip");
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_with_null_bytes() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let data: &[u8] = b"\x00\x01\x02\x00\xff\xfe\x00";
+        let py_bytes = api.bytes_from_slice(data);
+        assert!(!py_bytes.is_null());
+
+        let back = api.bytes_to_vec(py_bytes);
+        assert_eq!(
+            back.as_deref(),
+            Some(data),
+            "Bytes with embedded NULs must roundtrip exactly"
+        );
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_with_all_byte_values() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let data: Vec<u8> = (0..=255).collect();
+        let py_bytes = api.bytes_from_slice(&data);
+        assert!(!py_bytes.is_null());
+
+        let back = api.bytes_to_vec(py_bytes);
+        assert_eq!(
+            back.as_deref(),
+            Some(data.as_slice()),
+            "All 256 byte values must roundtrip"
+        );
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_check_type_discrimination() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_bytes = api.bytes_from_slice(b"test");
+        let py_str = api.string_from_str("test");
+        let py_int = api.long_from_i64(42);
+        let py_ba = api.bytearray_from_slice(b"test");
+
+        assert!(api.bytes_check(py_bytes), "bytes should pass bytes_check");
+        assert!(!api.bytes_check(py_str), "str should fail bytes_check");
+        assert!(!api.bytes_check(py_int), "int should fail bytes_check");
+        assert!(!api.bytes_check(py_ba), "bytearray should fail bytes_check");
+
+        api.decref(py_bytes);
+        api.decref(py_str);
+        api.decref(py_int);
+        api.decref(py_ba);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_check_null_returns_false() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        assert!(!guard.api().bytes_check(std::ptr::null_mut()));
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_to_vec_returns_none_for_non_bytes() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_str = api.string_from_str("not bytes");
+        assert!(api.bytes_to_vec(py_str).is_none());
+        api.decref(py_str);
+
+        let py_int = api.long_from_i64(42);
+        assert!(api.bytes_to_vec(py_int).is_none());
+        api.decref(py_int);
+
+        assert!(api.bytes_to_vec(std::ptr::null_mut()).is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_size() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_empty = api.bytes_from_slice(b"");
+        assert_eq!(
+            unsafe { (api.py_bytes_size)(py_empty) },
+            0,
+            "Empty bytes should have size 0"
+        );
+        api.decref(py_empty);
+
+        let py_hello = api.bytes_from_slice(b"hello");
+        assert_eq!(
+            unsafe { (api.py_bytes_size)(py_hello) },
+            5,
+            "b\"hello\" should have size 5"
+        );
+        api.decref(py_hello);
+
+        let data_with_nulls = b"\x00\x00\x00";
+        let py_nulls = api.bytes_from_slice(data_with_nulls);
+        assert_eq!(
+            unsafe { (api.py_bytes_size)(py_nulls) },
+            3,
+            "Size must count NUL bytes"
+        );
+        api.decref(py_nulls);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_from_python_eval() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+        let globals = make_globals(api);
+
+        let py_bytes = api
+            .run_string("b'hello world'", PY_EVAL_INPUT, globals, globals)
+            .expect("should eval bytes literal");
+        assert!(!py_bytes.is_null());
+        assert!(api.bytes_check(py_bytes));
+
+        let back = api.bytes_to_vec(py_bytes);
+        assert_eq!(back, Some(b"hello world".to_vec()));
+
+        api.decref(py_bytes);
+        api.decref(globals);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_is_not_string() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_bytes = api.bytes_from_slice(b"hello");
+        let py_str = api.string_from_str("hello");
+
+        assert!(!api.is_string(py_bytes), "bytes must not pass is_string");
+        assert!(!api.bytes_check(py_str), "str must not pass bytes_check");
+
+        api.decref(py_bytes);
+        api.decref(py_str);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_large_payload() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let data: Vec<u8> = (0..10_000).map(|i| (i % 256) as u8).collect();
+        let py_bytes = api.bytes_from_slice(&data);
+        assert!(!py_bytes.is_null());
+
+        let back = api
+            .bytes_to_vec(py_bytes)
+            .expect("should extract large bytes");
+        assert_eq!(back.len(), 10_000);
+        assert_eq!(back, data);
+
+        api.decref(py_bytes);
+    }
+
+    // ========== ByteArray operations ==========
+
+    #[test]
+    #[serial]
+    fn test_bytearray_from_slice_creates_object() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_ba = api.bytearray_from_slice(b"hello");
+        assert!(!py_ba.is_null(), "Should create a Python bytearray object");
+        assert!(api.bytearray_check(py_ba), "Should pass bytearray_check");
+        api.decref(py_ba);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_roundtrip() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        for data in [
+            b"hello" as &[u8],
+            b"world",
+            b"with spaces",
+            b"binary\xfe\xff",
+        ] {
+            let py_ba = api.bytearray_from_slice(data);
+            assert!(
+                !py_ba.is_null(),
+                "Failed to create bytearray for {:?}",
+                data
+            );
+
+            let back = api.bytearray_to_vec(py_ba);
+            assert_eq!(
+                back.as_deref(),
+                Some(data),
+                "Roundtrip failed for {:?}",
+                data
+            );
+            api.decref(py_ba);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_empty() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_ba = api.bytearray_from_slice(b"");
+        assert!(!py_ba.is_null(), "Should create empty Python bytearray");
+        assert!(api.bytearray_check(py_ba));
+
+        let back = api.bytearray_to_vec(py_ba);
+        assert_eq!(back, Some(Vec::new()), "Empty bytearray should roundtrip");
+        api.decref(py_ba);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_with_null_bytes() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let data: &[u8] = b"\x00\x01\x02\x00\xff\xfe\x00";
+        let py_ba = api.bytearray_from_slice(data);
+        assert!(!py_ba.is_null());
+
+        let back = api.bytearray_to_vec(py_ba);
+        assert_eq!(
+            back.as_deref(),
+            Some(data),
+            "Bytearray with embedded NULs must roundtrip exactly"
+        );
+        api.decref(py_ba);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_with_all_byte_values() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let data: Vec<u8> = (0..=255).collect();
+        let py_ba = api.bytearray_from_slice(&data);
+        assert!(!py_ba.is_null());
+
+        let back = api.bytearray_to_vec(py_ba);
+        assert_eq!(
+            back.as_deref(),
+            Some(data.as_slice()),
+            "All 256 byte values must roundtrip via bytearray"
+        );
+        api.decref(py_ba);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_check_type_discrimination() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_ba = api.bytearray_from_slice(b"test");
+        let py_bytes = api.bytes_from_slice(b"test");
+        let py_str = api.string_from_str("test");
+        let py_int = api.long_from_i64(42);
+
+        assert!(
+            api.bytearray_check(py_ba),
+            "bytearray should pass bytearray_check"
+        );
+        assert!(
+            !api.bytearray_check(py_bytes),
+            "bytes should fail bytearray_check"
+        );
+        assert!(
+            !api.bytearray_check(py_str),
+            "str should fail bytearray_check"
+        );
+        assert!(
+            !api.bytearray_check(py_int),
+            "int should fail bytearray_check"
+        );
+
+        api.decref(py_ba);
+        api.decref(py_bytes);
+        api.decref(py_str);
+        api.decref(py_int);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_check_null_returns_false() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        assert!(!guard.api().bytearray_check(std::ptr::null_mut()));
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_to_vec_returns_none_for_non_bytearray() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_str = api.string_from_str("not bytearray");
+        assert!(api.bytearray_to_vec(py_str).is_none());
+        api.decref(py_str);
+
+        let py_bytes = api.bytes_from_slice(b"not bytearray");
+        assert!(api.bytearray_to_vec(py_bytes).is_none());
+        api.decref(py_bytes);
+
+        assert!(api.bytearray_to_vec(std::ptr::null_mut()).is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_size() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_empty = api.bytearray_from_slice(b"");
+        assert_eq!(
+            unsafe { (api.py_bytearray_size)(py_empty) },
+            0,
+            "Empty bytearray should have size 0"
+        );
+        api.decref(py_empty);
+
+        let py_hello = api.bytearray_from_slice(b"hello");
+        assert_eq!(
+            unsafe { (api.py_bytearray_size)(py_hello) },
+            5,
+            "bytearray(b\"hello\") should have size 5"
+        );
+        api.decref(py_hello);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_from_python_eval() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+        let globals = make_globals(api);
+
+        let py_ba = api
+            .run_string("bytearray(b'hello world')", PY_EVAL_INPUT, globals, globals)
+            .expect("should eval bytearray");
+        assert!(!py_ba.is_null());
+        assert!(api.bytearray_check(py_ba));
+
+        let back = api.bytearray_to_vec(py_ba);
+        assert_eq!(back, Some(b"hello world".to_vec()));
+
+        api.decref(py_ba);
+        api.decref(globals);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_from_object() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_bytes = api.bytes_from_slice(b"convert me");
+        let py_ba = unsafe { (api.py_bytearray_from_object)(py_bytes) };
+        assert!(!py_ba.is_null(), "Should create bytearray from bytes");
+        assert!(api.bytearray_check(py_ba));
+
+        let back = api.bytearray_to_vec(py_ba);
+        assert_eq!(back, Some(b"convert me".to_vec()));
+
+        api.decref(py_ba);
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_is_not_bytes() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_ba = api.bytearray_from_slice(b"hello");
+        let py_bytes = api.bytes_from_slice(b"hello");
+
+        assert!(
+            !api.bytes_check(py_ba),
+            "bytearray must not pass bytes_check"
+        );
+        assert!(
+            !api.bytearray_check(py_bytes),
+            "bytes must not pass bytearray_check"
+        );
+        assert!(!api.is_string(py_ba), "bytearray must not pass is_string");
+
+        api.decref(py_ba);
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_large_payload() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let data: Vec<u8> = (0..10_000).map(|i| (i % 256) as u8).collect();
+        let py_ba = api.bytearray_from_slice(&data);
+        assert!(!py_ba.is_null());
+
+        let back = api
+            .bytearray_to_vec(py_ba)
+            .expect("should extract large bytearray");
+        assert_eq!(back.len(), 10_000);
+        assert_eq!(back, data);
+
+        api.decref(py_ba);
+    }
+
+    // ========== Cross-type bytes/bytearray tests ==========
+
+    #[test]
+    #[serial]
+    fn test_bytes_and_bytearray_same_content_different_types() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let data = b"identical content";
+        let py_bytes = api.bytes_from_slice(data);
+        let py_ba = api.bytearray_from_slice(data);
+
+        // Same content
+        let bytes_vec = api.bytes_to_vec(py_bytes).unwrap();
+        let ba_vec = api.bytearray_to_vec(py_ba).unwrap();
+        assert_eq!(bytes_vec, ba_vec, "Same input should produce same content");
+
+        // Different types
+        assert!(api.bytes_check(py_bytes));
+        assert!(!api.bytearray_check(py_bytes));
+        assert!(api.bytearray_check(py_ba));
+        assert!(!api.bytes_check(py_ba));
+
+        api.decref(py_bytes);
+        api.decref(py_ba);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_and_bytearray_neither_is_string() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_bytes = api.bytes_from_slice(b"data");
+        let py_ba = api.bytearray_from_slice(b"data");
+        let py_str = api.string_from_str("data");
+
+        assert!(!api.is_string(py_bytes));
+        assert!(!api.is_string(py_ba));
+        assert!(api.is_string(py_str));
+
+        assert!(!api.bytes_check(py_str));
+        assert!(!api.bytearray_check(py_str));
+
+        api.decref(py_bytes);
+        api.decref(py_ba);
+        api.decref(py_str);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytes_python_equality_with_rust() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+        let globals = make_globals(api);
+
+        // Create bytes in Python with hex escapes and verify Rust reads them correctly
+        let py_bytes = api
+            .run_string(
+                "b'\\x00\\x01\\x02\\xfd\\xfe\\xff'",
+                PY_EVAL_INPUT,
+                globals,
+                globals,
+            )
+            .expect("should eval hex bytes");
+        assert!(api.bytes_check(py_bytes));
+
+        let back = api.bytes_to_vec(py_bytes).unwrap();
+        assert_eq!(back, vec![0x00, 0x01, 0x02, 0xfd, 0xfe, 0xff]);
+
+        api.decref(py_bytes);
+        api.decref(globals);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bytearray_python_concatenation() {
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+        let globals = make_globals(api);
+
+        let py_ba = api
+            .run_string(
+                "bytearray(b'hello') + bytearray(b' world')",
+                PY_EVAL_INPUT,
+                globals,
+                globals,
+            )
+            .expect("should eval bytearray concat");
+        assert!(api.bytearray_check(py_ba));
+
+        let back = api.bytearray_to_vec(py_ba).unwrap();
+        assert_eq!(back, b"hello world");
+
+        api.decref(py_ba);
         api.decref(globals);
     }
 }

--- a/ext/rubyx/src/rubyx_object.rs
+++ b/ext/rubyx/src/rubyx_object.rs
@@ -4,10 +4,11 @@ use crate::python_ffi::PyObject;
 use crate::python_guard::PyGuard;
 use crate::ruby_helpers;
 use crate::stream::SendableValue;
+use magnus::encoding::EncodingCapable;
 use magnus::r_hash::ForEach;
 use magnus::typed_data::Obj;
 use magnus::value::ReprValue;
-use magnus::{Class, IntoValue, RHash, Ruby, Symbol, TryConvert, Value};
+use magnus::{Class, IntoValue, RHash, RString, Ruby, Symbol, TryConvert, Value};
 use std::ffi::CString;
 
 const RUBY_IMPLICIT_CONVERSIONS: &[&str] = &[
@@ -50,6 +51,24 @@ pub(crate) fn python_to_sendable(
             return Err("Cannot decode Python string as UTF-8".to_string());
         };
         return Ok(SendableValue::Str(val));
+    }
+    if api.bytes_check(py_val) {
+        let Some(val) = api.bytes_to_vec(py_val) else {
+            if api.has_error() {
+                api.clear_error();
+            }
+            return Err("Cannot decode Python bytes".to_string());
+        };
+        return Ok(SendableValue::Bytes(val));
+    }
+    if api.bytearray_check(py_val) {
+        let Some(val) = api.bytearray_to_vec(py_val) else {
+            if api.has_error() {
+                api.clear_error();
+            }
+            return Err("Cannot read Python bytearray".to_string());
+        };
+        return Ok(SendableValue::Bytes(val));
     }
     if api.tuple_check(py_val) {
         let len = api.tuple_size(py_val);
@@ -179,6 +198,24 @@ pub(crate) fn ruby_to_python(
         return Ok(py_str);
     }
     if value.is_kind_of(ruby.class_string()) {
+        let rstr = RString::try_convert(value)?;
+        // ASCII-8BIT means bytes/bytearray
+        let enc = rstr.enc_get();
+        let ascii_8_bit = ruby
+            .find_encindex("ASCII-8BIT")
+            .map_err(|_| magnus::Error::new(ruby_helpers::runtime_error(), "No ASCII-8BIT"))?;
+        if enc == ascii_8_bit {
+            let bytes = unsafe { rstr.as_slice() };
+            let py_bytes = api.bytes_from_slice(bytes);
+            if py_bytes.is_null() {
+                return Err(magnus::Error::new(
+                    ruby_helpers::runtime_error(),
+                    "Failed to create Python bytes from String",
+                ));
+            }
+            return Ok(py_bytes);
+        }
+        // UTF-8 string conversion
         let val = String::try_convert(value)?;
         return val
             .to_python(api)
@@ -2758,5 +2795,292 @@ mod tests {
             python_to_sendable(api.py_none, api),
             Ok(SendableValue::Nil)
         ));
+    }
+
+    // ========== python_to_sendable: bytes/bytearray ==========
+
+    #[test]
+    #[serial]
+    fn test_python_to_sendable_bytes() {
+        use crate::test_helpers::skip_if_no_python;
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_bytes = api.bytes_from_slice(b"hello");
+        let result = python_to_sendable(py_bytes, api);
+        assert!(
+            matches!(&result, Ok(SendableValue::Bytes(v)) if v == b"hello"),
+            "Python bytes should convert to SendableValue::Bytes, got: {:?}",
+            result
+        );
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_python_to_sendable_bytes_empty() {
+        use crate::test_helpers::skip_if_no_python;
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_bytes = api.bytes_from_slice(b"");
+        let result = python_to_sendable(py_bytes, api);
+        assert!(
+            matches!(&result, Ok(SendableValue::Bytes(v)) if v.is_empty()),
+            "Empty Python bytes should convert to empty Bytes, got: {:?}",
+            result
+        );
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_python_to_sendable_bytes_with_nulls() {
+        use crate::test_helpers::skip_if_no_python;
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let data: &[u8] = b"\x00\x01\xff\x00\xfe";
+        let py_bytes = api.bytes_from_slice(data);
+        let result = python_to_sendable(py_bytes, api);
+        assert!(
+            matches!(&result, Ok(SendableValue::Bytes(v)) if v.as_slice() == data),
+            "Bytes with NULs should roundtrip, got: {:?}",
+            result
+        );
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_python_to_sendable_bytearray() {
+        use crate::test_helpers::skip_if_no_python;
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_ba = api.bytearray_from_slice(b"world");
+        let result = python_to_sendable(py_ba, api);
+        assert!(
+            matches!(&result, Ok(SendableValue::Bytes(v)) if v == b"world"),
+            "Python bytearray should convert to SendableValue::Bytes, got: {:?}",
+            result
+        );
+        api.decref(py_ba);
+    }
+
+    #[test]
+    #[serial]
+    fn test_python_to_sendable_bytearray_empty() {
+        use crate::test_helpers::skip_if_no_python;
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_ba = api.bytearray_from_slice(b"");
+        let result = python_to_sendable(py_ba, api);
+        assert!(
+            matches!(&result, Ok(SendableValue::Bytes(v)) if v.is_empty()),
+            "Empty bytearray should convert to empty Bytes, got: {:?}",
+            result
+        );
+        api.decref(py_ba);
+    }
+
+    #[test]
+    #[serial]
+    fn test_python_to_sendable_bytes_not_string() {
+        use crate::test_helpers::skip_if_no_python;
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        // Python bytes must not produce SendableValue::Str
+        let py_bytes = api.bytes_from_slice(b"hello");
+        let result = python_to_sendable(py_bytes, api);
+        assert!(
+            !matches!(&result, Ok(SendableValue::Str(_))),
+            "Python bytes must not become Str"
+        );
+        assert!(
+            !matches!(&result, Ok(SendableValue::PyObjectRef(_))),
+            "Python bytes must not fall through to PyObjectRef"
+        );
+        api.decref(py_bytes);
+    }
+
+    #[test]
+    #[serial]
+    fn test_python_to_sendable_bytes_in_list() {
+        use crate::test_helpers::skip_if_no_python;
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        // [b"hello", 42, b"\x00\xff"]
+        let py_list = api.list_new(3);
+        api.list_set_item(py_list, 0, api.bytes_from_slice(b"hello"));
+        api.list_set_item(py_list, 1, api.long_from_i64(42));
+        api.list_set_item(py_list, 2, api.bytes_from_slice(b"\x00\xff"));
+
+        let result = python_to_sendable(py_list, api).expect("list with bytes should convert");
+        if let SendableValue::List(items) = result {
+            assert_eq!(items.len(), 3);
+            assert!(matches!(&items[0], SendableValue::Bytes(v) if v == b"hello"));
+            assert!(matches!(&items[1], SendableValue::Integer(42)));
+            assert!(matches!(&items[2], SendableValue::Bytes(v) if v == b"\x00\xff"));
+        } else {
+            panic!("Expected List, got: {:?}", result);
+        }
+        api.decref(py_list);
+    }
+
+    #[test]
+    #[serial]
+    fn test_python_to_sendable_bytes_as_dict_value() {
+        use crate::test_helpers::skip_if_no_python;
+        let Some(guard) = skip_if_no_python() else {
+            return;
+        };
+        let api = guard.api();
+
+        let py_dict = api.dict_new();
+        let key = api.string_from_str("data");
+        let val = api.bytes_from_slice(b"\xde\xad\xbe\xef");
+        api.dict_set_item(py_dict, key, val);
+        api.decref(key);
+        api.decref(val);
+
+        let result =
+            python_to_sendable(py_dict, api).expect("dict with bytes value should convert");
+        if let SendableValue::Dict(entries) = result {
+            assert_eq!(entries.len(), 1);
+            assert!(matches!(&entries[0].0, SendableValue::Str(s) if s == "data"));
+            assert!(matches!(&entries[0].1, SendableValue::Bytes(v) if v == b"\xde\xad\xbe\xef"));
+        } else {
+            panic!("Expected Dict, got: {:?}", result);
+        }
+        api.decref(py_dict);
+    }
+
+    // ========== ruby_to_python: ASCII-8BIT String → Python bytes ==========
+
+    #[test]
+    #[serial]
+    fn test_ruby_to_python_ascii_8bit_string_becomes_bytes() {
+        with_ruby_python(|ruby, api| {
+            let s = ruby.str_from_slice(b"hello");
+            s.enc_associate(
+                ruby.find_encoding("ASCII-8BIT")
+                    .expect("ASCII-8BIT must exist"),
+            )
+            .unwrap();
+
+            let py_obj = ruby_to_python(s.as_value(), api)
+                .expect("ASCII-8BIT string conversion should succeed");
+
+            assert!(api.bytes_check(py_obj), "Should produce Python bytes");
+            assert!(!api.is_string(py_obj), "Should NOT produce Python str");
+
+            let back = api.bytes_to_vec(py_obj).unwrap();
+            assert_eq!(back, b"hello");
+            api.decref(py_obj);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_ruby_to_python_ascii_8bit_empty() {
+        with_ruby_python(|ruby, api| {
+            let s = ruby.str_from_slice(b"");
+            s.enc_associate(
+                ruby.find_encoding("ASCII-8BIT")
+                    .expect("ASCII-8BIT must exist"),
+            )
+            .unwrap();
+
+            let py_obj =
+                ruby_to_python(s.as_value(), api).expect("empty ASCII-8BIT should convert");
+
+            assert!(api.bytes_check(py_obj));
+            let back = api.bytes_to_vec(py_obj).unwrap();
+            assert!(back.is_empty());
+            api.decref(py_obj);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_ruby_to_python_ascii_8bit_with_nulls() {
+        with_ruby_python(|ruby, api| {
+            let data: &[u8] = b"\x00\x01\x02\xff\xfe\x00";
+            let s = ruby.str_from_slice(data);
+            s.enc_associate(
+                ruby.find_encoding("ASCII-8BIT")
+                    .expect("ASCII-8BIT must exist"),
+            )
+            .unwrap();
+
+            let py_obj =
+                ruby_to_python(s.as_value(), api).expect("binary data with NULs should convert");
+
+            assert!(api.bytes_check(py_obj));
+            let back = api.bytes_to_vec(py_obj).unwrap();
+            assert_eq!(back, data);
+            api.decref(py_obj);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_ruby_to_python_utf8_string_stays_str() {
+        with_ruby_python(|ruby, api| {
+            // Regular UTF-8 string must still become Python str, not bytes
+            let py_str = ruby_to_python("hello".into_value_with(ruby), api)
+                .expect("UTF-8 string should convert");
+
+            assert!(api.is_string(py_str), "UTF-8 should produce Python str");
+            assert!(!api.bytes_check(py_str), "UTF-8 should NOT produce bytes");
+            assert_eq!(api.string_to_string(py_str), Some("hello".to_string()));
+            api.decref(py_str);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_ruby_to_python_ascii_8bit_roundtrip_via_sendable() {
+        with_ruby_python(|ruby, api| {
+            // Ruby ASCII-8BIT String → Python bytes → SendableValue::Bytes
+            let data: &[u8] = b"\xca\xfe\xba\xbe";
+            let s = ruby.str_from_slice(data);
+            s.enc_associate(
+                ruby.find_encoding("ASCII-8BIT")
+                    .expect("ASCII-8BIT must exist"),
+            )
+            .unwrap();
+
+            // Ruby → Python
+            let py_obj = ruby_to_python(s.as_value(), api).expect("should convert to Python");
+            assert!(api.bytes_check(py_obj));
+
+            // Python → SendableValue
+            let sendable = python_to_sendable(py_obj, api).expect("should convert to sendable");
+            assert!(
+                matches!(&sendable, SendableValue::Bytes(v) if v == data),
+                "Full roundtrip should preserve bytes, got: {:?}",
+                sendable
+            );
+            api.decref(py_obj);
+        });
     }
 }

--- a/ext/rubyx/src/rubyx_stream.rs
+++ b/ext/rubyx/src/rubyx_stream.rs
@@ -73,6 +73,7 @@ mod tests {
     use crate::stream::SendableValue;
     use crate::test_helpers::{skip_if_no_python, with_ruby_python};
     use crossbeam_channel::{bounded, unbounded};
+    use magnus::encoding::EncodingCapable;
     use magnus::value::ReprValue;
     use magnus::TryConvert;
     use serial_test::serial;
@@ -945,6 +946,173 @@ mod tests {
             let hash = magnus::RHash::try_convert(hash_val).expect("should be Hash");
             let v: i64 = hash.fetch("k").unwrap();
             assert_eq!(v, 99);
+        });
+    }
+
+    // ========== SendableValue::Bytes → Ruby String (ASCII-8BIT) ==========
+
+    #[test]
+    #[serial]
+    fn test_sendable_bytes_converts_to_ruby_string() {
+        with_ruby_python(|ruby, _api| {
+            let val: magnus::Value = SendableValue::Bytes(b"hello".to_vec())
+                .try_into()
+                .expect("Bytes conversion should succeed");
+
+            // Must be a Ruby String, not an Array of integers
+            let rstr = magnus::RString::try_convert(val).expect("should be a String");
+            let content = unsafe { rstr.as_slice() };
+            assert_eq!(content, b"hello");
+
+            // Verify encoding is ASCII-8BIT
+            let enc = rstr.enc_get();
+            let ascii_8bit = ruby
+                .find_encindex("ASCII-8BIT")
+                .expect("ASCII-8BIT must exist");
+            assert!(
+                enc == ascii_8bit,
+                "Bytes should produce ASCII-8BIT encoded String"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_sendable_bytes_empty() {
+        with_ruby_python(|ruby, _api| {
+            let val: magnus::Value = SendableValue::Bytes(Vec::new())
+                .try_into()
+                .expect("empty Bytes conversion should succeed");
+
+            let rstr = magnus::RString::try_convert(val).expect("should be a String");
+            let content = unsafe { rstr.as_slice() };
+            assert!(content.is_empty());
+
+            let enc = rstr.enc_get();
+            let ascii_8bit = ruby
+                .find_encindex("ASCII-8BIT")
+                .expect("ASCII-8BIT must exist");
+            assert!(enc == ascii_8bit, "encoding should be ASCII-8BIT");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_sendable_bytes_with_null_bytes() {
+        with_ruby_python(|ruby, _api| {
+            let data = vec![0x00, 0x01, 0xff, 0x00, 0xfe];
+            let val: magnus::Value = SendableValue::Bytes(data.clone())
+                .try_into()
+                .expect("Bytes with NULs should convert");
+
+            let rstr = magnus::RString::try_convert(val).expect("should be a String");
+            let content = unsafe { rstr.as_slice() };
+            assert_eq!(content, data.as_slice());
+
+            let enc = rstr.enc_get();
+            let ascii_8bit = ruby
+                .find_encindex("ASCII-8BIT")
+                .expect("ASCII-8BIT must exist");
+            assert!(enc == ascii_8bit, "encoding should be ASCII-8BIT");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_sendable_bytes_all_256_values() {
+        with_ruby_python(|ruby, _api| {
+            let data: Vec<u8> = (0..=255).collect();
+            let val: magnus::Value = SendableValue::Bytes(data.clone())
+                .try_into()
+                .expect("all byte values should convert");
+
+            let rstr = magnus::RString::try_convert(val).expect("should be a String");
+            let content = unsafe { rstr.as_slice() };
+            assert_eq!(content, data.as_slice());
+
+            let enc = rstr.enc_get();
+            let ascii_8bit = ruby
+                .find_encindex("ASCII-8BIT")
+                .expect("ASCII-8BIT must exist");
+            assert!(enc == ascii_8bit, "encoding should be ASCII-8BIT");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_sendable_bytes_is_not_array() {
+        with_ruby_python(|_ruby, _api| {
+            let val: magnus::Value = SendableValue::Bytes(b"test".to_vec())
+                .try_into()
+                .expect("Bytes conversion should succeed");
+
+            // Must NOT be an Array (Vec<u8>.into_value would produce Array<Integer>)
+            assert!(
+                magnus::RArray::try_convert(val).is_err(),
+                "Bytes must not convert to Ruby Array"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_sendable_bytes_in_stream_delivery() {
+        with_ruby_python(|ruby, _api| {
+            let (tx, rx) = unbounded();
+            let (cancel_tx, _cancel_rx) = bounded(1);
+
+            thread::spawn(move || {
+                tx.send(Some(SendableValue::Integer(1))).ok();
+                tx.send(Some(SendableValue::Bytes(b"\xde\xad".to_vec())))
+                    .ok();
+                tx.send(Some(SendableValue::Str("after".to_string()))).ok();
+                tx.send(None).ok();
+            });
+
+            let mut stream = crate::stream::AsyncStream::from_channel(rx, cancel_tx);
+
+            // First: integer
+            let val = stream.next().unwrap().unwrap();
+            assert_eq!(i64::try_convert(val).unwrap(), 1);
+
+            // Second: bytes → ASCII-8BIT String
+            let val = stream.next().unwrap().unwrap();
+            let rstr = magnus::RString::try_convert(val).expect("should be String");
+            let content = unsafe { rstr.as_slice() };
+            assert_eq!(content, b"\xde\xad");
+            let enc = rstr.enc_get();
+            let ascii_8bit = ruby
+                .find_encindex("ASCII-8BIT")
+                .expect("ASCII-8BIT must exist");
+            assert!(enc == ascii_8bit, "encoding should be ASCII-8BIT");
+
+            // Third: regular string
+            let val = stream.next().unwrap().unwrap();
+            assert_eq!(String::try_convert(val).unwrap(), "after");
+
+            assert!(stream.next().is_none());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_sendable_bytes_large_payload() {
+        with_ruby_python(|ruby, _api| {
+            let data: Vec<u8> = (0..10_000).map(|i| (i % 256) as u8).collect();
+            let val: magnus::Value = SendableValue::Bytes(data.clone())
+                .try_into()
+                .expect("large Bytes should convert");
+
+            let rstr = magnus::RString::try_convert(val).expect("should be a String");
+            let content = unsafe { rstr.as_slice() };
+            assert_eq!(content.len(), 10_000);
+            assert_eq!(content, data.as_slice());
+
+            let enc = rstr.enc_get();
+            let ascii_8bit = ruby
+                .find_encindex("ASCII-8BIT")
+                .expect("ASCII-8BIT must exist");
+            assert!(enc == ascii_8bit, "encoding should be ASCII-8BIT");
         });
     }
 }

--- a/ext/rubyx/src/stream.rs
+++ b/ext/rubyx/src/stream.rs
@@ -1,8 +1,9 @@
-use crate::api;
 use crate::python_ffi::PyObject;
 use crate::ruby_helpers::runtime_error;
 use crate::rubyx_object::{python_to_sendable, RubyxObject};
+use crate::{api, ruby_helpers};
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
+use magnus::encoding::EncodingCapable;
 use magnus::value::ReprValue;
 use magnus::{IntoValue, Value};
 use std::thread;
@@ -21,6 +22,7 @@ pub(crate) enum SendableValue {
     Float(f64),
     Str(String),
     Bool(bool),
+    Bytes(Vec<u8>),
     Set(Vec<SendableValue>),
     List(Vec<SendableValue>),
     Dict(Vec<(SendableValue, SendableValue)>),
@@ -39,6 +41,14 @@ impl TryInto<magnus::Value> for SendableValue {
             SendableValue::Float(f) => f.into_value_with(&ruby),
             SendableValue::Str(s) => s.as_str().into_value_with(&ruby),
             SendableValue::Bool(b) => b.into_value_with(&ruby),
+            SendableValue::Bytes(b) => {
+                let s = ruby.str_from_slice(&b);
+                s.enc_associate(ruby.find_encoding("ASCII-8BIT").ok_or(magnus::Error::new(
+                    ruby_helpers::no_method_error(),
+                    "No ASCII-8BIT",
+                ))?)?;
+                s.as_value()
+            }
             SendableValue::List(l) | SendableValue::Set(l) => {
                 let ruby_array = ruby.ary_new_capa(l.len());
                 for item in l {

--- a/spec/bytes_spec.rb
+++ b/spec/bytes_spec.rb
@@ -1,0 +1,180 @@
+require_relative 'spec_helper'
+
+RSpec.describe 'bytes and bytearray support', ruby_integration: true do
+  # ========== Python bytes -> Ruby ==========
+
+  describe 'Python bytes to Ruby' do
+    it 'converts bytes to Ruby String with ASCII-8BIT encoding' do
+      result = Rubyx.eval("b'hello'").to_ruby
+      expect(result).to eq("hello".b)
+      expect(result).to be_a(String)
+      expect(result.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    it 'converts empty bytes' do
+      result = Rubyx.eval("b''").to_ruby
+      expect(result).to eq("".b)
+      expect(result.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    it 'preserves null bytes' do
+      result = Rubyx.eval("b'\\x00\\x01\\x02'").to_ruby
+      expect(result).to eq("\x00\x01\x02".b)
+      expect(result.bytesize).to eq(3)
+    end
+
+    it 'preserves high bytes (non-UTF8)' do
+      result = Rubyx.eval("b'\\xff\\xfe\\xfd'").to_ruby
+      expect(result).to eq("\xff\xfe\xfd".b)
+      expect(result.bytesize).to eq(3)
+    end
+
+    it 'handles bytes with mixed content' do
+      result = Rubyx.eval("b'hello\\x00world'").to_ruby
+      expect(result).to eq("hello\x00world".b)
+      expect(result.bytesize).to eq(11)
+    end
+  end
+
+  # ========== Python bytearray -> Ruby ==========
+
+  describe 'Python bytearray to Ruby' do
+    it 'converts bytearray to Ruby String with ASCII-8BIT encoding' do
+      result = Rubyx.eval("bytearray(b'hello')").to_ruby
+      expect(result).to eq("hello".b)
+      expect(result).to be_a(String)
+      expect(result.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    it 'converts empty bytearray' do
+      result = Rubyx.eval("bytearray()").to_ruby
+      expect(result).to eq("".b)
+      expect(result.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    it 'converts bytearray from list of ints' do
+      result = Rubyx.eval("bytearray([0, 127, 255])").to_ruby
+      expect(result).to eq("\x00\x7f\xff".b)
+      expect(result.bytesize).to eq(3)
+    end
+  end
+
+  # ========== py_type ==========
+
+  describe '#py_type for bytes/bytearray' do
+    it 'returns "bytes" for bytes objects' do
+      expect(Rubyx.eval("b'hello'").py_type).to eq('bytes')
+    end
+
+    it 'returns "bytearray" for bytearray objects' do
+      expect(Rubyx.eval("bytearray(b'hello')").py_type).to eq('bytearray')
+    end
+  end
+
+  # ========== Ruby binary string -> Python ==========
+
+  describe 'Ruby binary string to Python' do
+    it 'passes ASCII-8BIT string as Python bytes via context kwargs' do
+      ctx = Rubyx::Context.new
+      ctx.eval("def check_type(x): return type(x).__name__")
+      result = ctx.eval('check_type(data)', data: "hello".b)
+      expect(result.to_ruby).to eq('bytes')
+    end
+
+    it 'passes UTF-8 string as Python str via context kwargs' do
+      ctx = Rubyx::Context.new
+      ctx.eval("def check_type(x): return type(x).__name__")
+      result = ctx.eval('check_type(data)', data: "hello")
+      expect(result.to_ruby).to eq('str')
+    end
+
+    it 'roundtrips binary data through Python' do
+      binary = "\x00\x01\xff\xfe\x80".b
+      ctx = Rubyx::Context.new
+      result = ctx.eval('data', data: binary)
+      ruby_result = result.to_ruby
+      expect(ruby_result).to eq(binary)
+      expect(ruby_result.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    it 'roundtrips empty binary string' do
+      binary = "".b
+      ctx = Rubyx::Context.new
+      result = ctx.eval('data', data: binary)
+      ruby_result = result.to_ruby
+      expect(ruby_result).to eq(binary)
+      expect(ruby_result.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+  end
+
+  # ========== Streaming bytes ==========
+
+  describe 'streaming bytes' do
+    it 'streams bytes values from a generator' do
+      gen = Rubyx.eval("iter([b'aaa', b'bbb', b'ccc'])")
+      results = Rubyx.stream(gen).to_a
+      expect(results).to all(be_a(String))
+      expect(results.map(&:encoding)).to all(eq(Encoding::ASCII_8BIT))
+      expect(results).to eq(["aaa".b, "bbb".b, "ccc".b])
+    end
+
+    it 'streams bytearray values from a generator' do
+      gen = Rubyx.eval("iter([bytearray(b'x'), bytearray(b'y')])")
+      results = Rubyx.stream(gen).to_a
+      expect(results).to all(be_a(String))
+      expect(results.map(&:encoding)).to all(eq(Encoding::ASCII_8BIT))
+      expect(results).to eq(["x".b, "y".b])
+    end
+
+    it 'streams mixed types including bytes' do
+      gen = Rubyx.eval("iter([1, b'hello', 'world', 3.14])")
+      results = Rubyx.stream(gen).to_a
+      expect(results[0]).to eq(1)
+      expect(results[1]).to eq("hello".b)
+      expect(results[1].encoding).to eq(Encoding::ASCII_8BIT)
+      expect(results[2]).to eq('world')
+      expect(results[3]).to be_within(0.001).of(3.14)
+    end
+  end
+
+  # ========== Bytes in nested structures ==========
+
+  describe 'bytes in nested structures' do
+    it 'converts bytes inside a list' do
+      result = Rubyx.eval("[b'a', b'b', b'c']").to_ruby
+      expect(result).to eq(["a".b, "b".b, "c".b])
+      expect(result).to all(be_a(String))
+      result.each { |s| expect(s.encoding).to eq(Encoding::ASCII_8BIT) }
+    end
+
+    it 'converts bytes inside a dict' do
+      result = Rubyx.eval("{'key': b'value'}").to_ruby
+      expect(result['key']).to eq("value".b)
+      expect(result['key'].encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    it 'converts bytes as dict keys' do
+      result = Rubyx.eval("{b'key': 42}").to_ruby
+      expect(result["key".b]).to eq(42)
+    end
+  end
+
+  # ========== Python stdlib integration ==========
+
+  describe 'Python stdlib with bytes' do
+    it 'works with base64 encode/decode' do
+      ctx = Rubyx::Context.new
+      ctx.eval("import base64")
+      encoded = ctx.eval("base64.b64encode(data)", data: "Hello, World!".b)
+      expect(encoded.to_ruby).to eq("SGVsbG8sIFdvcmxkIQ==".b)
+      expect(encoded.to_ruby.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    it 'works with hashlib' do
+      ctx = Rubyx::Context.new
+      ctx.eval("import hashlib")
+      digest = ctx.eval("hashlib.sha256(data).hexdigest()", data: "test".b)
+      expect(digest.to_ruby).to eq('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08')
+    end
+  end
+end


### PR DESCRIPTION
Bytes and ByteArray <-> `String(ASCII-8BIT)` between Python and Ruby